### PR TITLE
fixes construction of result types list from the introspection document

### DIFF
--- a/introspect.lisp
+++ b/introspect.lisp
@@ -107,7 +107,8 @@
                        (element :arg
                          (defaulted-attribute :direction "in"
                            (when (equal _ "out")
-                               (push _ result-types))
+                             (attribute :type
+                               (push _ result-types)))
                            (when (equal _ "in")
                              (attribute :name
                                (push _ parm-names))


### PR DESCRIPTION
Was only ever getting ("out") as the list of a method's return types. Fix is simple enough.
