### PR TITLE
Fix introspection parsing, add signals

### DIFF
--- a/introspect.lisp
+++ b/introspect.lisp
@@ -122,8 +122,8 @@
            (let (interface-name)
              (attribute :name (setf interface-name _))
              (let (methods properties)
-               (group
-                (zero-or-more
+               (zero-or-more
+                (one-of
                  (element :method
                    (let (method-name)
                      (attribute :name (setf method-name _))
@@ -149,8 +149,7 @@
                                           (reverse parm-names)
                                           (reverse parm-types)
                                           (reverse result-types))
-                             methods)))))
-                (zero-or-more
+                             methods))))
                  (element :property
                    (let (property-name property-type property-access)
                      (attribute :name (setf property-name _))

--- a/messages.lisp
+++ b/messages.lisp
@@ -6,6 +6,9 @@
 
 
 ;;;; Encoding and decoding messages
+;;;;
+;;;; See
+;;;; http://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-marshaling
 
 (defun encode-message (endianness type flags major-protocol-version
                        serial path interface member error-name reply-serial
@@ -85,7 +88,8 @@
       (with-binary-readers (stream endianness)
         (align 8)
         (let (body path interface member error-name
-              reply-serial destination sender signature)
+              reply-serial destination sender signature
+              unix-fds)
           (loop for (field-code field-value) in fields
                 do (case field-code
                      (1 (setf path field-value))
@@ -96,6 +100,7 @@
                      (6 (setf destination field-value))
                      (7 (setf sender field-value))
                      (8 (setf signature field-value))
+                     (9 (setf unix-fds field-value))
                      (t (warn "Unknown field code ~D; ignoring field." field-code))))
           (setf body (unpack stream endianness signature))
           (macrolet ((make-message (class-name &rest additional-initargs)

--- a/packages.lisp
+++ b/packages.lisp
@@ -26,7 +26,7 @@
                 #:with-output-to-sequence)
   (:import-from #:trivial-garbage #:make-weak-hash-table)
   (:import-from #:ieee-floats #:encode-float64 #:decode-float64)
-  (:shadow #:method #:make-method)
+  (:shadow #:method #:make-method #:signal)
   (:export
    ;; Utilities
    #:inexistent-entry
@@ -125,8 +125,10 @@
    #:interface-name
    #:interface-method
    #:interface-property
+   #:interface-signal
    #:list-interface-methods
    #:list-interface-properties
+   #:list-interface-signals
    #:method-name
    #:method-signature
    #:method-argument-names
@@ -135,6 +137,9 @@
    #:property-name
    #:property-type
    #:property-access
+   #:signal-name
+   #:signal-argument-names
+   #:signal-argument-types
    #:parse-introspection-document
    #:make-object-from-introspection
    #:object-invoke

--- a/packages.lisp
+++ b/packages.lisp
@@ -12,7 +12,7 @@
   (:import-from #:xspam
                 #:with-xspam-source #:make-xspam-source #:element
                 #:one-or-more #:attribute #:_ #:zero-or-more
-                #:optional-attribute #:group)
+                #:optional-attribute #:one-of)
   (:import-from #:babel #:string-to-octets #:octets-to-string)
   (:import-from #:ironclad #:digest-sequence)
   (:import-from #:iolib


### PR DESCRIPTION
The three commits
* fix parsing of `method` and `property` introspection elements
* add basic support for signals to introspection
* recognize but do not further process unix-fd fields in messages