### PR TITLE
Use UID instead of username for external authentication

### DIFF
--- a/auth-dbus-external.lisp
+++ b/auth-dbus-external.lisp
@@ -4,6 +4,7 @@
 
 (defpackage #:dbus/auth-dbus-external
   (:use #:cl #:dbus/utils #:dbus/protocols #:dbus/authentication-mechanisms)
+  (:import-from #:iolib.syscalls #:getuid)
   (:export
    #:dbus-external-authentication-mechanism))
 
@@ -22,5 +23,5 @@
 
 (defmethod feed-authentication-mechanism ((mechanism dbus-external-authentication-mechanism) challenge)
   (if (eq challenge :initial-response)
-      (values :continue (encode-hex-string (current-username)))
+      (values :continue (encode-hex-string (write-to-string (getuid))))
       (error "More than one response requested for EXTERNAL authentication.")))


### PR DESCRIPTION
This fixed the authentication to the system dbus for me.