### PR TITLE
Implement Properties

### DIFF
--- a/all.lisp
+++ b/all.lisp
@@ -159,4 +159,5 @@
    #:define-dbus-object
    #:define-dbus-method
    #:define-dbus-signal-handler
+   #:define-dbus-property
    #:publish-objects))

--- a/examples/publish.lisp
+++ b/examples/publish.lisp
@@ -15,6 +15,10 @@
   (:interface "org.adeht.MyService")
   (concatenate 'string s1 s2))
 
+(define-dbus-property (my-service my-property)
+  (:interface "org.adeht.MyService")
+  "initial-property-value")
+
 (define-dbus-signal-handler (my-service on-signal) ((s :string))
   (:interface "org.adeht.MyService")
   (format t "Got signal with arg ~S~%" s))


### PR DESCRIPTION
This brings initial support for properties. For each registered dbus-object we preimplement the `org.freedesktop.DBus.Properties` interface.

With this commit, only the `Get` method is supported. The `GetAll` method is lacking and signals for property changes are not emitted as well.

More info on DBus properties:

https://dbus.freedesktop.org/doc/dbus-api-design.html#interface-properties

I can work more on extending the properties support if you are interested.